### PR TITLE
Improve Geocoder Reliability and Performance

### DIFF
--- a/app/models/weather_fetcher.rb
+++ b/app/models/weather_fetcher.rb
@@ -6,8 +6,8 @@ class WeatherFetcher
   end
 
   def call
-    coords = Geocoder.search(@address)&.first&.coordinates
-    return { error: "Could not geocode address: #{@address}" } unless coords
+    coords = safe_geocode(@address)
+    return { error: "Could not geocode address: #{@address}. Try again later." } unless coords
     lat, lon = coords
     point_response = HTTParty.get("https://api.weather.gov/points/#{lat},#{lon}", headers: headers)
     parsed_response = JSON.parse(point_response)
@@ -30,6 +30,12 @@ class WeatherFetcher
   end
 
   private
+
+  def safe_geocode(address)
+    Geocoder.search(address)&.first&.coordinates
+  rescue StandardError
+    nil
+  end
 
   def headers
     {

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,0 +1,27 @@
+Geocoder.configure(
+  # Geocoding options
+  timeout: 20,                 # geocoding service timeout (secs)
+  # lookup: :nominatim,         # name of geocoding service (symbol)
+  # ip_lookup: :ipinfo_io,      # name of IP address geocoding service (symbol)
+  # language: :en,              # ISO-639 language code
+  # use_https: false,           # use HTTPS for lookup requests? (if supported)
+  # http_proxy: nil,            # HTTP proxy server (user:pass@host:port)
+  # https_proxy: nil,           # HTTPS proxy server (user:pass@host:port)
+  # api_key: nil,               # API key for geocoding service
+  cache: Geocoder::CacheStore::Generic.new(Rails.cache, {}),
+
+  # Exceptions that should not be rescued by default
+  # (if you want to implement custom error handling);
+  # supports SocketError and Timeout::Error
+  # always_raise: [],
+
+  # Calculation options
+  # units: :mi,                 # :km for kilometers or :mi for miles
+  # distances: :linear          # :spherical or :linear
+
+  # Cache configuration
+  cache_options: {
+    expiration: 30.minutes,
+    prefix: "geocoder:"
+  }
+)

--- a/spec/models/weather_fetcher_spec.rb
+++ b/spec/models/weather_fetcher_spec.rb
@@ -89,6 +89,12 @@ RSpec.describe WeatherFetcher do
     expect(result[:error]).to match(/Could not geocode address/)
   end
 
+  it "returns an error if Geocoder raises an exception" do
+    allow(Geocoder).to receive(:search).with(address).and_raise(StandardError)
+    result = WeatherFetcher.new(address).call
+    expect(result[:error]).to match(/Could not geocode address/)
+  end
+
   it "returns an error if API response is missing forecast URLs" do
     stub_request(:get, %r{https://api.weather.gov/points/.*})
       .to_return(status: 200, body: { properties: {} }.to_json)


### PR DESCRIPTION
- Increased Geocoder timeout to 20 seconds to better handle slow responses from geocoding services.
- Enabled caching for Geocoder lookups using Rails.cache with a 30-minute expiration and a custom prefix for improved performance and reduced API calls.
- Added robust error handling in WeatherFetcher to gracefully handle geocoding failures and exceptions, ensuring users receive clear error messages instead of indefinite loading or missing content.
- Added/updated tests to cover both geocoding failures (empty results) and exceptions.